### PR TITLE
skip 'ldap' CRL DistributionPoint URI

### DIFF
--- a/nagios/check_ssl_validity
+++ b/nagios/check_ssl_validity
@@ -217,6 +217,10 @@ if ($opt_d) {
 @crldps = @{$decoded->CRLDistributionPoints};
 $crlskip = 0;
 foreach $crldp (@crldps) {
+    # skip 'ldap' CRL DistributionPoint URI
+    if ( $crldp =~ /^ldap.*/ ) {
+        next;
+    }
     if ($opt_d) {
         print "Checking CRL DP $crldp.\n";
     }


### PR DESCRIPTION
currently we have no support to download from 'ldap' CRLDP URI ... 
... so hence it is best to skip